### PR TITLE
Add React micro frontends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+**/node_modules
+frontends/dist

--- a/README.md
+++ b/README.md
@@ -2,4 +2,16 @@
 
 Repositorio de ejemplo con una propuesta de arquitectura de microservicios para una tienda estilo Uber Eats.
 
-Consulta la documentaci\u00f3n en [docs/architecture.md](docs/architecture.md).
+Consulta la documentación en [docs/architecture.md](docs/architecture.md).
+
+## Micro Frontends
+
+En la carpeta `frontends` se encuentra un ejemplo básico en React que consume cada microservicio. Para ejecutarlo debes tener las dependencias instaladas y luego iniciar el servidor de desarrollo:
+
+```bash
+cd frontends
+npm install
+npm run start
+```
+
+Esto levantará la aplicación en `http://localhost:8080`, desde donde podrás probar la creación de usuarios, restaurantes, órdenes y pagos.

--- a/frontends/.babelrc
+++ b/frontends/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/frontends/package.json
+++ b/frontends/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "micro-frontends",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  }
+}

--- a/frontends/public/index.html
+++ b/frontends/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Micro Frontends</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontends/src/App.js
+++ b/frontends/src/App.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import UserFrontend from './components/UserFrontend';
+import RestaurantFrontend from './components/RestaurantFrontend';
+import OrderFrontend from './components/OrderFrontend';
+import PaymentFrontend from './components/PaymentFrontend';
+
+function App() {
+  const [active, setActive] = useState('users');
+  return (
+    <div>
+      <h1>Micro Frontends</h1>
+      <nav>
+        <button onClick={() => setActive('users')}>Users</button>
+        <button onClick={() => setActive('restaurants')}>Restaurants</button>
+        <button onClick={() => setActive('orders')}>Orders</button>
+        <button onClick={() => setActive('payments')}>Payments</button>
+      </nav>
+      <div>
+        {active === 'users' && <UserFrontend />}
+        {active === 'restaurants' && <RestaurantFrontend />}
+        {active === 'orders' && <OrderFrontend />}
+        {active === 'payments' && <PaymentFrontend />}
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontends/src/api/order.js
+++ b/frontends/src/api/order.js
@@ -1,0 +1,8 @@
+export async function createOrder(order) {
+  const response = await fetch('http://localhost:3003/orders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(order)
+  });
+  return response.json();
+}

--- a/frontends/src/api/payment.js
+++ b/frontends/src/api/payment.js
@@ -1,0 +1,8 @@
+export async function createPayment(payment) {
+  const response = await fetch('http://localhost:3004/payments', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payment)
+  });
+  return response.json();
+}

--- a/frontends/src/api/restaurant.js
+++ b/frontends/src/api/restaurant.js
@@ -1,0 +1,8 @@
+export async function createRestaurant(restaurant) {
+  const response = await fetch('http://localhost:3002/restaurants', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(restaurant)
+  });
+  return response.json();
+}

--- a/frontends/src/api/user.js
+++ b/frontends/src/api/user.js
@@ -1,0 +1,8 @@
+export async function createUser(user) {
+  const response = await fetch('http://localhost:3001/users', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(user)
+  });
+  return response.json();
+}

--- a/frontends/src/components/OrderFrontend.js
+++ b/frontends/src/components/OrderFrontend.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { createOrder } from '../api/order';
+
+function OrderFrontend() {
+  const [userId, setUserId] = useState('');
+  const [restaurantId, setRestaurantId] = useState('');
+  const [response, setResponse] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const order = await createOrder({ user_id: userId, restaurant_id: restaurantId, items: [] });
+    setResponse(order);
+    setUserId('');
+    setRestaurantId('');
+  };
+
+  return (
+    <div>
+      <h2>Order Service</h2>
+      <form onSubmit={handleSubmit}>
+        <input value={userId} onChange={(e) => setUserId(e.target.value)} placeholder="User ID" />
+        <input value={restaurantId} onChange={(e) => setRestaurantId(e.target.value)} placeholder="Restaurant ID" />
+        <button type="submit">Create Order</button>
+      </form>
+      {response && <pre>{JSON.stringify(response, null, 2)}</pre>}
+    </div>
+  );
+}
+
+export default OrderFrontend;

--- a/frontends/src/components/PaymentFrontend.js
+++ b/frontends/src/components/PaymentFrontend.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { createPayment } from '../api/payment';
+
+function PaymentFrontend() {
+  const [orderId, setOrderId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [response, setResponse] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const payment = await createPayment({ order_id: orderId, amount });
+    setResponse(payment);
+    setOrderId('');
+    setAmount('');
+  };
+
+  return (
+    <div>
+      <h2>Payment Service</h2>
+      <form onSubmit={handleSubmit}>
+        <input value={orderId} onChange={(e) => setOrderId(e.target.value)} placeholder="Order ID" />
+        <input value={amount} onChange={(e) => setAmount(e.target.value)} placeholder="Amount" />
+        <button type="submit">Create Payment</button>
+      </form>
+      {response && <pre>{JSON.stringify(response, null, 2)}</pre>}
+    </div>
+  );
+}
+
+export default PaymentFrontend;

--- a/frontends/src/components/RestaurantFrontend.js
+++ b/frontends/src/components/RestaurantFrontend.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { createRestaurant } from '../api/restaurant';
+
+function RestaurantFrontend() {
+  const [name, setName] = useState('');
+  const [address, setAddress] = useState('');
+  const [response, setResponse] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const restaurant = await createRestaurant({ name, address });
+    setResponse(restaurant);
+    setName('');
+    setAddress('');
+  };
+
+  return (
+    <div>
+      <h2>Restaurant Service</h2>
+      <form onSubmit={handleSubmit}>
+        <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" />
+        <input value={address} onChange={(e) => setAddress(e.target.value)} placeholder="Address" />
+        <button type="submit">Create Restaurant</button>
+      </form>
+      {response && <pre>{JSON.stringify(response, null, 2)}</pre>}
+    </div>
+  );
+}
+
+export default RestaurantFrontend;

--- a/frontends/src/components/UserFrontend.js
+++ b/frontends/src/components/UserFrontend.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { createUser } from '../api/user';
+
+function UserFrontend() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [response, setResponse] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const user = await createUser({ name, email });
+    setResponse(user);
+    setName('');
+    setEmail('');
+  };
+
+  return (
+    <div>
+      <h2>User Service</h2>
+      <form onSubmit={handleSubmit}>
+        <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" />
+        <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
+        <button type="submit">Create User</button>
+      </form>
+      {response && <pre>{JSON.stringify(response, null, 2)}</pre>}
+    </div>
+  );
+}
+
+export default UserFrontend;

--- a/frontends/src/index.js
+++ b/frontends/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/frontends/webpack.config.js
+++ b/frontends/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: 'public/index.html'
+    })
+  ],
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public')
+    },
+    port: 8080
+  }
+};


### PR DESCRIPTION
## Summary
- add base React setup in `frontends` to consume each microservice
- expose simple forms for users, restaurants, orders and payments
- document how to run the micro frontends
- add `.gitignore`

## Testing
- `npm run build` *(fails: webpack not found because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68558991555c83308c4d5c9309f6daf7